### PR TITLE
add missing apostrophe in the dependencies section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'org.kordamp.gradle:{project-name}:{plugin-version}
+        classpath 'org.kordamp.gradle:{project-name}:{plugin-version}'
     }
 }
 apply plugin: 'org.kordamp.jdeps'


### PR DESCRIPTION
There is a missing apostrophe symbol in the dependencies section 