### PR TITLE
Fixed order of statements user needs to add in the build.gradle file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,8 @@ Runs the `jdeps` command on the project's output and all of its dependencies.
 
 == Usage
 
+In your **project** `build.gradle` file, add...
+
 [source,groovy]
 [subs="attributes"]
 ----
@@ -26,19 +28,17 @@ buildscript {
         classpath 'org.kordamp.gradle:{project-name}:{plugin-version}'
     }
 }
-apply plugin: 'org.kordamp.jdeps'
-----
 
-[source,groovy]
-[subs="attributes"]
-----
 plugins {
     id 'org.kordamp.jdeps' version '{plugin-version}'
 }
-----
 
-This will add a `jdeps` task to your build, which will analyze the `main` sourceSets and all dependencies found in the
-`runtime` configuration.
+apply plugin: 'org.kordamp.jdeps'
+.
+.
+.
+----
+This will add a `jdeps` task to your build, which will analyze the `main` sourceSets and all dependencies found in the `runtime` configuration.
 
 == Configuration
 === Plugin configuration


### PR DESCRIPTION
When I tried to implement the instructions in the README, I encountered an issue with the order of the statements a user needs to add to project's `build.gradle` file. The order of the statements is important:

1. Add dependency classpath
2. Add `plugins {...}`
3. Add `apply plugin:...`
